### PR TITLE
chore: print number of established connections in windowed output

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1867,7 +1867,7 @@ func reportStaticProgress(ctx context.Context, stats *WorkloadStats, testTime in
 
 // createStaticProgressBar creates a progress bar for static workload
 func createStaticProgressBar(elapsed, total time.Duration) string {
-	barWidth := 10
+	barWidth := 20
 	progress := float64(elapsed) / float64(total)
 	if progress > 1.0 {
 		progress = 1.0

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -154,16 +154,6 @@ func (ps *PerformanceStats) GetPreviousWindowStats() (int64, int64, int64, int64
 		histToUse.Max()
 }
 
-// GetOverallStats returns overall statistics
-func (ps *PerformanceStats) GetOverallStats() (int64, int64, int64, float64) {
-	total := atomic.LoadInt64(&ps.TotalOps)
-	success := atomic.LoadInt64(&ps.SuccessOps)
-	failed := atomic.LoadInt64(&ps.FailedOps)
-	qps := ps.GetQPS()
-
-	return total, success, failed, qps
-}
-
 // Close shuts down the stats collector goroutine
 func (ps *PerformanceStats) Close() {
 	close(ps.done)


### PR DESCRIPTION
increments an atomic int with each new fully established client and includes that int in the windowed output

also did a little more cleanup (remove unused stats function, make windowed output spacing a little nicer, revert bar width change I'd made in previous PR so bar widths are all consistent again)